### PR TITLE
Remove assembly definition that is incompatible with unity iap 2.1.0 …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+src/ApprienUnitySDK/Assets/do_not_push_token.asset.meta
+src/ApprienUnitySDK/Assets/Apprien/Editor/do_not_push_token.asset.meta

--- a/src/ApprienUnitySDK/Assets/Apprien/Scripts/ApprienAsmDef.asmdef
+++ b/src/ApprienUnitySDK/Assets/Apprien/Scripts/ApprienAsmDef.asmdef
@@ -1,8 +1,0 @@
-{
-    "name": "ApprienUnitySDK",
-    "references": [],
-    "optionalUnityReferences": [],
-    "includePlatforms": [],
-    "excludePlatforms": [],
-    "allowUnsafeCode": false
-}

--- a/src/ApprienUnitySDK/Assets/Apprien/Scripts/ApprienAsmDef.asmdef.meta
+++ b/src/ApprienUnitySDK/Assets/Apprien/Scripts/ApprienAsmDef.asmdef.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 48af208d289c7f043b79c8f42949d306
-AssemblyDefinitionImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Removed Assembly Definition file that made Apprien Unity SDK incompatible with games/apps that use Unity IAP 2.1.0 or later. (Newer unity IAP needs an assembly reference for UnityEngine.Purchasing and out Assembly definition can not make the reference, if we want to also support old unity iap 2.0.6 and earlier.)